### PR TITLE
pass key_transform value as string instead of symbol

### DIFF
--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -65,11 +65,11 @@ describe Serializer::Base do
 
     context "with options" do
       it { single_serializer.serialize(opts: {:test => true}).should_not contain(%("Title")) }
-      it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("TITLE")) }
+      it { single_serializer.serialize(opts: {:key_transform => "upcase"}).should contain(%("TITLE")) }
 
       context "with root key" do
-        it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("DATA")) }
-        it { single_serializer.serialize(opts: {:key_transform => :upcase}, meta: { :count => 0}).should contain(%("META")) }
+        it { single_serializer.serialize(opts: {:key_transform => "upcase"}).should contain(%("DATA")) }
+        it { single_serializer.serialize(opts: {:key_transform => "upcase"}, meta: { :count => 0}).should contain(%("META")) }
       end
     end
 
@@ -87,7 +87,7 @@ describe Serializer::Base do
 
       context "with opts" do
         it do
-          single_serializer.serialize(meta: {:page => 0}, opts: { :key_transform => :upcase }).should contain(%("PAGE"))
+          single_serializer.serialize(meta: {:page => 0}, opts: { :key_transform => "upcase" }).should contain(%("PAGE"))
         end
       end
     end

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -167,15 +167,15 @@ module Serializer
       # not the best code
       if opts && opts.has_key?(:key_transform)
         case opts[:key_transform]
-        when :camelcase_down
+        when "camelcase_down"
           string.camelcase(lower: true)
-        when :camelcase_up
+        when "camelcase_up"
           string.camelcase
-        when :upcase
+        when "upcase"
           string.upcase
-        when :downcase
+        when "downcase"
           string.downcase
-        when :underscore
+        when "underscore"
           string.underscore
         else
           string


### PR DESCRIPTION
Another quick hack to accept transformation value from url. It's a pain to convert string to symbol.