### PR TITLE
Dynamic root key

### DIFF
--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -16,7 +16,7 @@ end
 
 class ModelWithRootSerializer < ModelSerializer
   def self.root_key
-    "model_with_root" 
+    "model_with_root"
   end
 end
 

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -14,6 +14,12 @@ class ModelWithoutRootSerializer < ModelSerializer
   end
 end
 
+class ModelWithRootSerializer < ModelSerializer
+  def self.root_key
+    "model_with_root" 
+  end
+end
+
 describe Serializer::Base do
   single_serializer = ModelSerializer.new(Model.new)
 
@@ -95,6 +101,16 @@ describe Serializer::Base do
     context "without root" do
       it do
         ModelWithoutRootSerializer.new(Model.new).serialize.should eq("{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}")
+      end
+
+    end
+
+    context "dynamic root" do
+      context "without default root" do
+        ModelWithoutRootSerializer.new(Model.new).serialize(opts: { :root_key => "model" }).should eq("{\"model\":{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}}")
+      end
+      context "with default root" do
+        ModelWithRootSerializer.new(Model.new).serialize(opts: { :root_key => "model" }).should eq("{\"model\":{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}}")
       end
     end
   end

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -164,6 +164,7 @@ module Serializer
     # :nodoc:
     def key_transform(string, opts)
       return string if string.nil?
+      string = string.as(String)
       # not the best code
       if opts && opts.has_key?(:key_transform)
         case opts[:key_transform]
@@ -205,7 +206,8 @@ module Serializer
 
     # :nodoc:
     def render_root(io : IO, except : Array, includes : Array | Hash, opts : Hash?, meta)
-      key = key_transform(self.class.root_key, opts)
+      root_key = (opts && opts.has_key?(:root_key)) ? opts[:root_key] : self.class.root_key
+      key = key_transform(root_key, opts)
       io << "{\"" << key << "\":"
       _serialize(@target, io, except, includes, opts)
       default_meta = self.class.meta(opts)

--- a/src/serializer/serializable.cr
+++ b/src/serializer/serializable.cr
@@ -69,10 +69,11 @@ module Serializer
     #     :children => {:address => nil, :dipper => [:address]},
     #   },
     #   meta: {:page => 0},
-    #   opts: { :key_transform => :camelcase_up }
+    #   opts: { :key_transform => "camelcase_up", :root_key => "people" }
     # )
     # ```
-    # *key_transform* can either be :upcase, :downcase, :underscore, :camelcase_down or :camelcase_up
+    # *key_transform* can either be "upcase", "downcase", "underscore", "camelcase_down" or "camelcase_up"
+    # *root_key* dynamically sets the root key, overriding the default one
     # ## Includes
     #
     # *includes* option accepts `Array` or `Hash` values. To define just a list of association of target object - just pass an array:
@@ -92,7 +93,7 @@ module Serializer
 
     # :nodoc:
     def serialize(io : IO, except = %i(), includes = %i(), opts : Hash? = nil, meta : Hash? = nil)
-      if self.class.root_key.nil?
+      if self.class.root_key.nil? && !(opts && opts.has_key?(:root_key))
         _serialize(@target, io, except, includes, opts)
       else
         render_root(io, except, includes, opts, meta)


### PR DESCRIPTION
Add a way to set/override the root key during serialize. Useful for those times when you need to pluralize or translate the root key.